### PR TITLE
Fix for crash at the hot plug source/sink and resource clean up at shutdown

### DIFF
--- a/router-dbusif.c
+++ b/router-dbusif.c
@@ -743,8 +743,10 @@ router_dbusif *router_dbusif_init(struct userdata *u, router_init_data_t* init_d
  * @return void
  */
 
-void router_dbusif_done(struct router_dbusif *routerif) {
+void router_dbusif_done(struct userdata *u) {
     ROUTER_FUNCTION_ENTRY;
+    free_routerif(u);
+    router_dbusif* routerif = u->dbusif;
     MODULE_ROUTER_FREE(routerif->pulse_router_dbus_return_interface_name);
     MODULE_ROUTER_FREE(routerif->pulse_router_dbus_name);
     MODULE_ROUTER_FREE(routerif->pulse_router_dbus_interface_name);
@@ -757,6 +759,7 @@ void router_dbusif_done(struct router_dbusif *routerif) {
     MODULE_ROUTER_FREE(routerif->am_routing_dbus_path);
     MODULE_ROUTER_FREE(routerif->am_watch_rule);
     MODULE_ROUTER_FREE(routerif);
+
     ROUTER_FUNCTION_EXIT;
 
 }
@@ -1677,7 +1680,6 @@ static void free_routerif(struct userdata *u) {
 
             pa_dbus_connection_unref(routerif->conn);
         }
-        pa_xfree(routerif);
     }
     ROUTER_FUNCTION_EXIT;
 }

--- a/router-dbusif.h
+++ b/router-dbusif.h
@@ -173,7 +173,7 @@ typedef struct {
 } router_init_data_t;
 
 router_dbusif *router_dbusif_init(struct userdata *u, router_init_data_t* init_data);
-void router_dbusif_done(struct router_dbusif *routerif);
+void router_dbusif_done(struct userdata *u);
 
 int router_dbusif_command_connect(struct userdata *u, am_main_connection_t* data);
 int router_dbusif_command_disconnect(struct userdata *u, am_disconnect_t* data);


### PR DESCRIPTION
In the hook_sink_new and hook_source_new callbacks the data structure passed is pa_source/sink_new_data and not the pa_source/sink, due to de-referencing of mismatched datatype pointer a crash was observed during the hotplug of USB Audio Device. 
The clean at the shutdown was missing. As a result a crash was observed at the termination.

Signed-off-by: Kapildev Patel <kpatel@jp.adit-jv.com>