### PR TITLE
Fix access of empty proplist description

### DIFF
--- a/module-router.c
+++ b/module-router.c
@@ -2034,11 +2034,11 @@ int pa__init(pa_module *m) {
             PA_HOOK_LATE + 30, (pa_hook_cb_t) hook_callback_source_output_put, u);
     u->h->hook_slot_source_output_unlink = pa_hook_connect(&m->core->hooks[PA_CORE_HOOK_SOURCE_OUTPUT_UNLINK],
             PA_HOOK_LATE + 30, (pa_hook_cb_t) hook_callback_source_output_unlink, u);
-    u->h->hook_slot_sink_new = pa_hook_connect(&m->core->hooks[PA_CORE_HOOK_SINK_NEW], PA_HOOK_LATE + 30,
+    u->h->hook_slot_sink_new = pa_hook_connect(&m->core->hooks[PA_CORE_HOOK_SINK_FIXATE], PA_HOOK_LATE + 30,
             (pa_hook_cb_t) hook_callback_sink_new, u);
     u->h->hook_slot_sink_input_new = pa_hook_connect(&m->core->hooks[PA_CORE_HOOK_SINK_INPUT_NEW], PA_HOOK_LATE + 30,
             (pa_hook_cb_t) hook_callback_sink_input_new, u);
-    u->h->hook_slot_source_new = pa_hook_connect(&m->core->hooks[PA_CORE_HOOK_SOURCE_NEW], PA_HOOK_LATE + 30,
+    u->h->hook_slot_source_new = pa_hook_connect(&m->core->hooks[PA_CORE_HOOK_SOURCE_FIXATE], PA_HOOK_LATE + 30,
             (pa_hook_cb_t) hook_callback_source_new, u);
     u->h->hook_slot_source_output_new = pa_hook_connect(&m->core->hooks[PA_CORE_HOOK_SOURCE_OUTPUT_NEW],
             PA_HOOK_LATE + 30, (pa_hook_cb_t) hook_callback_source_output_new, u);


### PR DESCRIPTION
When adding a new sink or source, the router module fires
hook_callback_[sink|source]_new() with the new sink/source
data. The pulseaudio core fires the PA_CORE_HOOK_SINK_NEW and
PA_CORE_HOOK_SOURCE_NEW hooks before proplist is initialized
in the supplied data argument. The result is that in certain
cases, the callback routine runs and finds an null string for
the device description property which registers an empty sink
or source for AudioManager thereby causing AudioManager to
assert on the empty sink/source name. This is fixed by hooking
the later PA_CORE_HOOK_SINK_FIXATE and
PA_CORE_HOOK_SOURCE_FIXATE hooks which are fired after
proplist has been initialized.

Signed-off-by: Matt Porter <mporter@konsulko.com>